### PR TITLE
fix: properly detect replicated-job service completion status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,30 @@ GitHub Action and Docker image used to deploy a Docker stack on a Docker Swarm.
 | `remote_user` | `REMOTE_USER` | User with SSH and Docker privileges on the machine running the Docker Swarm manager node. | ✅ | |
 | `remote_private_key` | `REMOTE_PRIVATE_KEY` | Private key used for ssh authentication. | ✅ | |
 | `deploy_timeout` | `DEPLOY_TIMEOUT` | Seconds, to wait until the deploy finishes | | **600** |
+| `skip_jobs` | `SKIP_JOBS` | Skip waiting for replicated-job services (migrations, etc.) | | **0** |
 | `stack_file` | `STACK_FILE` | Path to the stack file used in the deploy. | ✅ | |
 | `stack_name` | `STACK_NAME` | Name of the stack to be deployed. | ✅ | |
 | `stack_param` | `STACK_PARAM` | Additional parameter (env var) to be passed to the stack. | | |
 | `env_file` | `ENV_FILE` | Additional environment variables to be passed to the stack. | | |
 | `debug` | `DEBUG` | Verbose logging | | **0** |
 
+
+## Replicated Job Support
+
+This action fully supports Docker Swarm's `replicated-job` mode (one-shot jobs like database migrations). Services configured with `deploy.mode: replicated-job` are automatically detected and their completion status is properly parsed from Docker's output format `0/1 (1/1 completed)`.
+
+**Options:**
+- By default, the action waits for jobs to complete just like regular services
+- Set `skip_jobs: "1"` to skip waiting for job services entirely (useful when jobs may take a long time but aren't critical to the deployment)
+
+**Example with migrations:**
+```yaml
+- name: Deploy
+  uses: etracksystems/docker-stack-deploy@v1.1.3
+  with:
+    # ... other options
+    skip_jobs: "0"  # Wait for migrations to complete (default)
+```
 
 ## Using the GitHub Action
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: "Timeout for the deploy check (in seconds)"
     required: false
     default: "600"
+  skip_jobs:
+    description: "Skip waiting for replicated-job services (one-shot jobs like migrations)"
+    required: false
+    default: "0"
   stack_file:
     description: "Path to the stack file to be used for deploy"
     required: true
@@ -75,6 +79,7 @@ runs:
     REMOTE_PRIVATE_KEY: ${{ inputs.remote_private_key }}
     REMOTE_JUMPBOX: ${{ inputs.remote_jumpbox }}
     DEPLOY_TIMEOUT: ${{ inputs.deploy_timeout }}
+    SKIP_JOBS: ${{ inputs.skip_jobs }}
     STACK_FILE: ${{ inputs.stack_file }}
     STACK_OVERRIDE_FILE: ${{ inputs.stack_override_file }}
     STACK_NAME: ${{ inputs.stack_name }}

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -88,7 +88,12 @@ deploy() {
 
 check_deploy() {
   echo "Deploy: Checking status"
-  /stack-wait.sh -t "${DEPLOY_TIMEOUT}" "${STACK_NAME}"
+  skip_jobs_flag=""
+  if [ "${SKIP_JOBS}" = "1" ] || [ "${SKIP_JOBS}" = "true" ]; then
+    skip_jobs_flag="-j"
+    echo "Deploy: Skipping replicated-job services"
+  fi
+  /stack-wait.sh -t "${DEPLOY_TIMEOUT}" ${skip_jobs_flag} "${STACK_NAME}"
 }
 
 [ -z ${DEBUG+x} ] && export DEBUG="0"


### PR DESCRIPTION
## Summary
- Fixes false deployment failures when using `replicated-job` services (e.g., database migrations)
- The `stack-wait.sh` script now properly detects job completion by parsing Docker's `(X/Y completed)` output format
- Adds optional `skip_jobs` input to skip waiting for job services entirely

## Root Cause
Docker reports completed jobs as `0/1 (1/1 completed)`. The script only parsed `0/1` and thought jobs were still "replicating" when they had actually completed successfully.

## Changes
- `scripts/stack-wait.sh`: Add job detection helpers, `-j` skip flag, always-on job logging
- `scripts/docker-entrypoint.sh`: Pass `SKIP_JOBS` env to stack-wait.sh
- `action.yml`: Add `skip_jobs` input parameter (default: disabled)
- `README.md`: Document replicated-job support and new option

## Testing
To test this fix:
1. Deploy a stack with `replicated-job` services (e.g., database migrations)
2. Observe that the script correctly detects `completed (job)` state
3. Verify deployment succeeds instead of timing out